### PR TITLE
Chord ID's and ease

### DIFF
--- a/res/config/ukulele.json
+++ b/res/config/ukulele.json
@@ -28,6 +28,12 @@
     {
       "name"  : "Cdim",
       "base"  : 1,
+      "frets" : [ 5, 3, 2, 3 ],
+      "easy"  : 0,
+    },
+    {
+      "name"  : "Cdim7",
+      "base"  : 1,
       "frets" : [ 2, 3, 2, 3 ],
       "easy"  : 0,
     },
@@ -52,13 +58,13 @@
     {
       "name"  : "C9",
       "base"  : 1,
-      "frets" : [ 0, 2, 2, 1 ],
+      "frets" : [ 0, 2, 0, 1 ],
       "easy"  : 0,
     },
     {
       "name"  : "Db",
       "base"  : 1,
-      "frets" : [ 1, 1, 1, 3 ],
+      "frets" : [ 1, 1, 1, 4 ],
       "easy"  : 0,
     },
     {
@@ -70,14 +76,14 @@
     {
       "name"  : "Dbm",
       "base"  : 1,
-      "frets" : [ 1, 1, 0, 3 ],
+      "frets" : [ 1, 1, 0, 4 ],
       "easy"  : 0,
     },
     {
       "name"  : "Dbm7",
       "base"  : 1,
       "frets" : [ 4, 4, 4, 4 ],
-      "easy"  : 0,
+      "easy"  : 1,
     },
     {
       "name"  : "Dbdim",
@@ -95,7 +101,7 @@
       "name"  : "Db6",
       "base"  : 1,
       "frets" : [ 1, 1, 1, 1 ],
-      "easy"  : 0,
+      "easy"  : 1,
     },
     {
       "name"  : "Dbmaj7",
@@ -135,6 +141,12 @@
     },
     {
       "name"  : "Ddim",
+      "base"  : 1,
+      "frets" : [ 1, 2, 1, -1 ],
+      "easy"  : 0,
+    },
+    {
+      "name"  : "Ddim7",
       "base"  : 1,
       "frets" : [ 1, 2, 1, 2 ],
       "easy"  : 0,
@@ -190,6 +202,12 @@
     {
       "name"  : "Ebdim",
       "base"  : 1,
+      "frets" : [ 2, 3, 2, 0 ],
+      "easy"  : 0,
+    },
+    {
+      "name"  : "Ebdim7",
+      "base"  : 1,
       "frets" : [ 2, 3, 2, 3 ],
       "easy"  : 0,
     },
@@ -203,12 +221,12 @@
       "name"  : "Eb6",
       "base"  : 1,
       "frets" : [ 3, 3, 3, 3 ],
-      "easy"  : 0,
+      "easy"  : 1,
     },
     {
       "name"  : "Ebmaj7",
       "base"  : 1,
-      "frets" : [ 3, 3, 3, 0 ],
+      "frets" : [ 3, 3, 3, 5 ],
       "easy"  : 0,
     },
     {
@@ -227,7 +245,7 @@
       "name"  : "E7",
       "base"  : 1,
       "frets" : [ 1, 2, 0, 2 ],
-      "easy"  : 0,
+      "easy"  : 1,
     },
     {
       "name"  : "Em",
@@ -256,7 +274,7 @@
     {
       "name"  : "E6",
       "base"  : 1,
-      "frets" : [ 1, 0, 2, 0 ],
+      "frets" : [ 1, 1, 0, 2 ],
       "easy"  : 0,
     },
     {
@@ -358,7 +376,7 @@
     {
       "name"  : "Gbaug",
       "base"  : 1,
-      "frets" : [ 4, 3, 2, 2 ],
+      "frets" : [ 3, 2, 2, 1 ],
       "easy"  : 0,
     },
     {
@@ -370,7 +388,7 @@
     {
       "name"  : "Gbmaj7",
       "base"  : 1,
-      "frets" : [ 0, 1, 1, 1 ],
+      "frets" : [ 3, 5, 2, 4 ],
       "easy"  : 0,
     },
     {
@@ -425,7 +443,7 @@
       "name"  : "Gmaj7",
       "base"  : 1,
       "frets" : [ 0, 2, 2, 2 ],
-      "easy"  : 0,
+      "easy"  : 1,
     },
     {
       "name"  : "G9",
@@ -454,7 +472,7 @@
     {
       "name"  : "Abm7",
       "base"  : 1,
-      "frets" : [ 0, 3, 2, 2 ],
+      "frets" : [ 1, 3, 2, 2 ],
       "easy"  : 0,
     },
     {
@@ -466,7 +484,7 @@
     {
       "name"  : "Abaug",
       "base"  : 1,
-      "frets" : [ 1, 0, 0, 0 ],
+      "frets" : [ 1, 0, 0, 3 ],
       "easy"  : 0,
     },
     {
@@ -479,7 +497,7 @@
       "name"  : "Abmaj7",
       "base"  : 1,
       "frets" : [ 1, 3, 3, 3 ],
-      "easy"  : 0,
+      "easy"  : 1,
     },
     {
       "name"  : "Ab9",
@@ -508,7 +526,7 @@
     {
       "name"  : "Am7",
       "base"  : 1,
-      "frets" : [ 0, 4, 3, 3 ],
+      "frets" : [ 0, 0, 0, 0 ],
       "easy"  : 1,
     },
     {
@@ -526,7 +544,7 @@
     {
       "name"  : "A6",
       "base"  : 1,
-      "frets" : [ 1, 3, 1, 3 ],
+      "frets" : [ 2, 4, 2, 4 ],
       "easy"  : 0,
     },
     {
@@ -563,7 +581,7 @@
       "name"  : "Bbm7",
       "base"  : 1,
       "frets" : [ 1, 1, 1, 1 ],
-      "easy"  : 0,
+      "easy"  : 1,
     },
     {
       "name"  : "Bbdim",
@@ -599,7 +617,7 @@
       "name"  : "B",
       "base"  : 1,
       "frets" : [ 4, 3, 2, 2 ],
-      "easy"  : 0,
+      "easy"  : 1,
     },
     {
       "name"  : "B7",
@@ -611,13 +629,13 @@
       "name"  : "Bm",
       "base"  : 1,
       "frets" : [ 4, 2, 2, 2 ],
-      "easy"  : 0,
+      "easy"  : 1,
     },
     {
       "name"  : "Bm7",
       "base"  : 1,
       "frets" : [ 2, 2, 2, 2 ],
-      "easy"  : 0,
+      "easy"  : 1,
     },
     {
       "name"  : "Bdim",


### PR DESCRIPTION
Some of them were just transpositions of others and shouldn't have necessarily been marked "hard". Others had the wrong tones associated. Kept the 9 chords as rootless 9ths. Changed "dim" which were actually "dim7" to "dim7"; added missing "dim" chords (1-b3-b5).